### PR TITLE
Make root README a module overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Gradle Plugins
+
+This is a multi-module repository that hosts Gradle plugins published under the `io.github.denis-markushin` group.
+
+## Modules
+
+Each plugin lives in its own subdirectory with a dedicated README describing usage and configuration. See:
+
+- `jcabi-gradle-plugin/README.md`


### PR DESCRIPTION
### Motivation
- The repository is a multi-module project and the root README should present a high-level overview rather than document a single plugin.
- The previous root README contained `jcabi-gradle-plugin`-specific instructions which do not belong at the repository root.
- Keep plugin-specific installation and usage guidance in each plugin subdirectory so it is easier to maintain and discover.
- Provide a clear pointer from the root to per-module documentation so consumers and the Gradle Plugin Portal see a concise repository landing page.

### Description
- Replace the root `README.md` content with a brief multi-module overview that describes the repository purpose.
- Remove plugin-specific documentation from the root and add a pointer to `jcabi-gradle-plugin/README.md` (and other module READMEs).
- No source code, build scripts, or plugin behavior were modified by this change.
- The new root README is intentionally minimal to serve as a repository-level index of modules.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cfb54aa3c832b8887df41dc3ff546)