### PR TITLE
ci: harden workflows with setup-gradle, least-privilege permissions, …

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   make-release:
     runs-on: ubuntu-latest
@@ -54,7 +58,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -64,7 +68,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-          cache: 'gradle'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Make release
         env:

--- a/.github/workflows/gradle-ci.yml
+++ b/.github/workflows/gradle-ci.yml
@@ -6,7 +6,14 @@ on:
       - "master"
   pull_request:
     branches:
-      - "*"
+      - "**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -15,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -24,7 +31,42 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-          cache: 'gradle'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build with Gradle
-        run: ./gradlew -p build-logic build --no-daemon
+        run: ./gradlew -p build-logic build
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            build-logic/*/build/reports/tests/
+            build-logic/*/build/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  dependency-submission:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Submit dependency graph
+        uses: gradle/actions/dependency-submission@v5
+        with:
+          build-root-directory: build-logic

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -5,6 +5,13 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-plugin-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   gradle:
     runs-on: ubuntu-latest
@@ -14,7 +21,7 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up JDK 21
@@ -22,8 +29,8 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - name: Cache Gradle Caches
-        uses: gradle/actions/setup-gradle@v5
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
       - name: Resolve release branch from tag
         id: vercraft
         run: |


### PR DESCRIPTION
…concurrency

- Replace setup-java cache:'gradle' with gradle/actions/setup-gradle@v5 for better caching and build scan support across all workflows.
- Add explicit permissions blocks (contents: read default; write only where required) to follow least-privilege.
- Add concurrency groups: CI cancels in-progress on PR pushes; release and publish never cancel mid-run.
- Drop --no-daemon from CI build; setup-gradle handles daemon lifecycle.
- Upload test reports as artifact on CI failure for diagnostics.
- Split dependency-submission into its own job (needs contents: write) that runs only on master push.
- Fix pull_request branch glob ('*' -> '**').
- Rename publish-plugin.yaml -> .yml for consistency.