### PR TITLE
feat(spring-service): auto-wire dema graphql starters into dgsCodegen…

### DIFF
--- a/build-logic/spring-service/build.gradle.kts
+++ b/build-logic/spring-service/build.gradle.kts
@@ -13,6 +13,9 @@ buildConfig {
     buildConfigField("MAPSTRUCT_PROCESSOR_DEP", libs.mapstruct.processor.get().toString())
     buildConfigField("MAPSTRUCT_SPRING_ANNOTATIONS_DEP", libs.mapstruct.spring.annotations.get().toString())
     buildConfigField("MAPSTRUCT_SPRING_EXTENSIONS_DEP", libs.mapstruct.spring.extensions.get().toString())
+    // Dema
+    buildConfigField("DEMA_GRAPHQL_STARTER_DEP", libs.dema.graphql.starter.get().toString())
+    buildConfigField("DEMA_GRAPHQL_SCALARS_DEP", libs.dema.graphql.scalars.get().toString())
     // Testing
     buildConfigField("JUNIT_LAUNCHER_DEP", libs.junit.launcher.get().toString())
     buildConfigField("SPRING_BOOT_TEST_DEP", libs.spring.boot.test.get().toString())

--- a/build-logic/spring-service/src/main/kotlin/io/github/denismarkushin/gradle/configurator/NetflixDgsRequiredDependenciesConfigurator.kt
+++ b/build-logic/spring-service/src/main/kotlin/io/github/denismarkushin/gradle/configurator/NetflixDgsRequiredDependenciesConfigurator.kt
@@ -3,6 +3,8 @@ package io.github.denismarkushin.gradle.configurator
 import com.netflix.graphql.dgs.codegen.gradle.CodegenPlugin
 import com.netflix.graphql.dgs.codegen.gradle.GenerateJavaTask
 import io.github.denismarkushin.gradle.extension.DemaPlatformExtension
+import io.github.denismarkushin.gradle.springservice.VersionCatalog.DEMA_GRAPHQL_SCALARS_DEP
+import io.github.denismarkushin.gradle.springservice.VersionCatalog.DEMA_GRAPHQL_STARTER_DEP
 import io.github.denismarkushin.gradle.springservice.VersionCatalog.NETFLIX_DGS_BOM_DEP
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
@@ -28,6 +30,12 @@ internal fun Project.configureNetflixDgsFramework() {
         if (!dgsExt.useNetflixDgs.get()) return@afterEvaluate
 
         plugins.apply(CodegenPlugin::class)
+
+        // Auto-wire dema common GraphQL schema starters into dgsCodegen so codegen sees
+        // PageInfo / Node / MutationResult / error types / scalars from the shared starter.
+        // Services no longer need to declare these in their own `dependencies { }` blocks.
+        dependencies.add("dgsCodegen", DEMA_GRAPHQL_STARTER_DEP)
+        dependencies.add("dgsCodegen", DEMA_GRAPHQL_SCALARS_DEP)
 
         val generator = dgsExt.generator
         tasks.withType<GenerateJavaTask>().configureEach {

--- a/build-logic/spring-service/src/test/kotlin/io/github/denismarkushin/gradle/SpringBootServicePluginTest.kt
+++ b/build-logic/spring-service/src/test/kotlin/io/github/denismarkushin/gradle/SpringBootServicePluginTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.doesNotContain
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import io.github.denismarkushin.gradle.extension.DemaPlatformExtension
 import org.gradle.api.Project
@@ -172,6 +173,40 @@ class SpringBootServicePluginTest {
         fun `netflix dgs BOM not added when useNetflixDgs is false`() {
             val implDeps = project.configurations.getByName("implementation").dependencies
             assertThat(implDeps.any { it.name == "graphql-dgs-platform-dependencies" }).isFalse()
+        }
+
+        @Test
+        fun `dgsCodegen wiring adds dema starter and scalars when useNetflixDgs is true`() {
+            val p = buildProjectWithExtension {
+                spring {
+                    netflixDgs {
+                        useNetflixDgs.set(true)
+                    }
+                }
+            }
+
+            val dgsCodegen = p.configurations.findByName("dgsCodegen")
+            assertThat(dgsCodegen).isNotNull()
+
+            val deps = dgsCodegen!!.allDependencies.map { "${it.group}:${it.name}" }
+            assertAll {
+                assertThat(deps).contains("io.github.denis-markushin:graphql-dgs-starter")
+                assertThat(deps).contains("io.github.denis-markushin:common-scalars-starter")
+            }
+        }
+
+        @Test
+        fun `dgsCodegen wiring is absent when useNetflixDgs is false`() {
+            val p = buildProjectWithExtension {
+                spring {
+                    netflixDgs {
+                        useNetflixDgs.set(false)
+                    }
+                }
+            }
+
+            val dgsCodegen = p.configurations.findByName("dgsCodegen")
+            assertThat(dgsCodegen).isNull()
         }
 
         @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ git-properties-plugin = "2.5.4"
 mapstruct = "1.6.3"
 mapstruct-spring = "2.0.0"
 jooq = "3.19.24"
-dema-libs = "0.3.0"
+dema-libs = "0.4.0"
 
 # Test
 assertk = "0.28.1"
@@ -36,6 +36,8 @@ mapstruct-spring-extensions = { module = "org.mapstruct.extensions.spring:mapstr
 jcabiAspects = { module = "com.jcabi:jcabi-aspects", version = "0.26.0" }
 jooq-codegen = { module = "org.jooq:jooq-codegen", version.ref = "jooq" }
 dema-jooq-liquibase-tc = { module = "io.github.denis-markushin:jooq-liquibase-testcontainer", version.ref = "dema-libs" }
+dema-graphql-starter = { module = "io.github.denis-markushin:graphql-dgs-starter", version.ref = "dema-libs" }
+dema-graphql-scalars = { module = "io.github.denis-markushin:common-scalars-starter", version.ref = "dema-libs" }
 
 # Test libs
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
@@ -59,4 +61,4 @@ spotless = { id = "com.diffplug.spotless", version = "7.2.1" }
 jooq-codegen = { id = "org.jooq.jooq-codegen-gradle", version.ref = "jooq" }
 vercraft = { id = "com.akuleshov7.vercraft.plugin-gradle", version = "0.8.0" }
 vanniktechMavenPublish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }
-ben-manes-versions = { id = "com.github.ben-manes.versions", version = "0.52.0" }
+ben-manes-versions = { id = "com.github.ben-manes.versions", version = "0.54.0" }


### PR DESCRIPTION
… config

Services no longer need to:
  - import + apply CodegenPlugin eagerly
  - declare "dgsCodegen"(libs.dema.graphql.starter / scalars) manually

Both happen inside the existing afterEvaluate block when useNetflixDgs = true. opt-in semantics preserved.